### PR TITLE
Link relative e gruppi telegram

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -16,9 +16,9 @@ Ho scelto GitBook proprio perché è facile collaborare, è visibile bene anche 
 
 **To Do:**
 
-* ✔️ [Link a gruppi, social, siti](/social.md)
-* ✔️ [Link ufficiali dell'Università](/link-ufficiali.md)
-* ✔️ [Immatricolazioni](/immatricolarsi.md)
+* ✔️ [Link a gruppi, social, siti](social.md)
+* ✔️ [Link ufficiali dell'Università](link-ufficiali.md)
+* ✔️ [Immatricolazioni](immatricolarsi.md)
 * Elenco di tutti i corsi con sigle e link
 * Edifici del Polo Fibonacci e uffici, aule studio / laboratori
 * Mensa, attivare e usare la tessera, link

--- a/src/social.md
+++ b/src/social.md
@@ -39,7 +39,7 @@ Il consiglio è di entrare in quello generico per vedere avvisi generali, e in q
 Telegram ormai è figo. Offre un metodo di comunicare rapido e facile, se per caso ancora non lo abbiate [scaricatelo subito](https://telegram.org/dl)!
 Abbiamo un gruppo pubblico generico per tutti gli studenti, per unirvi [cliccate qui](https://t.me/informaticaunipi) oppure cercate **@informaticaunipi**.
 
-Usatelo per chattare senza problemi riguardo quello , se avete domande di un certo corso inserite l'hashtag con la sigla corrispondente _\(es. **\#PRL**\)_. Trovate un elenco di sigle [in questo paragrafo](/sigle.md) ma non preoccupatevi, le sentirete così spesso che vi si imprimeranno violentemente nella mente.
+Usatelo per chattare senza problemi riguardo quello , se avete domande di un certo corso inserite l'hashtag con la sigla corrispondente _\(es. **\#PRL**\)_. Trovate un elenco di sigle [in questo paragrafo](sigle.md) ma non preoccupatevi, le sentirete così spesso che vi si imprimeranno violentemente nella mente.
 
 #### InformateciBot
 

--- a/src/social.md
+++ b/src/social.md
@@ -46,6 +46,13 @@ Usatelo per chattare senza problemi riguardo quello , se avete domande di un cer
 Oltre il gruppo, esiste un bot che fornisce alcune funzioni interessanti, come trovare aule libere, o file e libri pronti da scaricare.
 Lo trovate qui: [@informatecibot](https://t.me/informatecibot).
 
+#### Gruppo immatricolati 2017-18
+Gruppo del primo anno di informatica: per unirvi [@informaticaunipi1718](https://t.me/informaticaunipi1718).
+
+#### Crittografia
+Groppo solo per crittografia (a.a. 2017/18) per non spammare sul gruppone generale: per unirvi [cliccate qui](https://t.me/joinchat/AnWsLRDWt_mF_4hSuJe1OA).
+
+
 ## Forum
 
 Facebook e Telegram rappresentano un modo veloce e immediato di comunicare, ma per diffondere informazioni utili a tutti che resistano alle generazioni future abbiamo un forum \(sì, esistono ancora, e dovreste usarlo!\).


### PR DESCRIPTION
Ho messo i link relative (qualcosa.md) invece di (/qualcosa.md). Funzionano lo stesso sul sito ma ora anche su git dove avevi spostato l'intera cartella in src e cliccando sul link cercava il file nella root del progetto.

Ho aggiunto i link ai gruppi Telegram del primo anno e di CRI